### PR TITLE
Fixed incorrect click listener bindings in ScreenBinder.

### DIFF
--- a/app/src/main/java/com/nugget/hios/ui/common/ScreenBinder.java
+++ b/app/src/main/java/com/nugget/hios/ui/common/ScreenBinder.java
@@ -69,7 +69,8 @@ public final class ScreenBinder {
 
         View about = root.findViewById(R.id.btn_about);
         if (about != null) {
-            appearance.setOnClickListener(view -> {
+            // FIXED: Was 'appearance.setOnClickListener'
+            about.setOnClickListener(view -> {
                 if (activity instanceof HiClubSettingsActivity) {
                     ((HiClubSettingsActivity) activity).openAbout();
                 }
@@ -78,7 +79,8 @@ public final class ScreenBinder {
 
         View privacyPolicy = root.findViewById(R.id.btn_privacypolicy);
         if (privacyPolicy != null) {
-            appearance.setOnClickListener(view -> {
+            // FIXED: Was 'appearance.setOnClickListener'
+            privacyPolicy.setOnClickListener(view -> {
                 if (activity instanceof HiClubSettingsActivity) {
                     ((HiClubSettingsActivity) activity).openPrivacyPolicy();
                 }


### PR DESCRIPTION
Corrected an issue where `about` and `privacyPolicy` views were erroneously attempting to set click listeners on the `appearance` view instead of themselves.