### PR TITLE
v3.1: Native Help Center & UI Refinements

### DIFF
--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <option name="previewPanelProviderInfo">
+      <ProviderInfo name="Compose (experimental)" className="com.intellij.markdown.compose.preview.ComposePanelProvider" />
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/.idea/studiobot.xml
+++ b/.idea/studiobot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="StudioBotProjectSettings">
+    <option name="shareContext" value="OptedIn" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdk 24
         targetSdk 36
         versionCode 5
-        versionName "3.0"
+        versionName "3.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,14 @@
                 android:value="com.nugget.hios.MainActivity" />
         </activity>
         <activity
+            android:name=".HelpcenterActivity"
+            android:label="@string/title_activity_help"
+            android:exported="false">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.nugget.hios.MainActivity" />
+        </activity>
+        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"

--- a/app/src/main/java/com/nugget/hios/HelpcenterActivity.java
+++ b/app/src/main/java/com/nugget/hios/HelpcenterActivity.java
@@ -9,7 +9,17 @@ import androidx.fragment.app.Fragment;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 import com.google.android.material.appbar.MaterialToolbar;
+import com.nugget.hios.ui.comingsoon.ComingsoonFragment;
 import com.nugget.hios.ui.common.GenericLayoutFragment;
+import com.nugget.hios.ui.feedback.FeedbackFragment;
+import com.nugget.hios.ui.helpcenter.HotelFragment;
+import com.nugget.hios.ui.helpcenter.InternetFragment;
+import com.nugget.hios.ui.helpcenter.RestaurantFragment;
+import com.nugget.hios.ui.helpcenter.RoomkeyFragment;
+import com.nugget.hios.ui.helpcenter.TutorialFragment;
+import com.nugget.hios.ui.helpcenter.UpdatesFragment;
+import com.nugget.hios.ui.support.SupportFragment;
+import com.nugget.hios.ui.tc.TcFragment;
 
 public class HelpcenterActivity extends AppCompatActivity {
 
@@ -79,6 +89,45 @@ public class HelpcenterActivity extends AppCompatActivity {
     }
 
     //called from HelpcenterHomeFragment
+    public void openTutorial() {
+        loadFragment(new TutorialFragment(), "Navigation Tutorial");
+    }
+
+    public void openFood() {
+        loadFragment(new RestaurantFragment(), "Eat");
+    }
+
+    public void openHotel() {
+        loadFragment(new HotelFragment(), "Stay");
+    }
+
+    public void openRoomkey() {
+        loadFragment(new RoomkeyFragment(), "Room Key");
+    }
+
+    public void openSupport() {
+        loadFragment(new SupportFragment(), "Customer Support");
+    }
+
+    public void openInternet() {
+        loadFragment(new InternetFragment(), "WiFi and Internet");
+    }
+
+    public void openUpdates() {
+        loadFragment(new UpdatesFragment(), "Updates");
+    }
+
+    public void comingSoon() {
+        loadFragment(new ComingsoonFragment(), "Coming Soon");
+    }
+
+    public void termsConditions() {
+        loadFragment(new TcFragment(), "Terms and Conditions");
+    }
+
+    public void sendFeedback() {
+        loadFragment(new FeedbackFragment(), "Send Feedback");
+    }
 
     /*e.g...
         public void openUpdates() {

--- a/app/src/main/java/com/nugget/hios/HelpcenterActivity.java
+++ b/app/src/main/java/com/nugget/hios/HelpcenterActivity.java
@@ -10,25 +10,22 @@ import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.nugget.hios.ui.common.GenericLayoutFragment;
-import com.nugget.hios.ui.preferences.AboutFragment;
-import com.nugget.hios.ui.preferences.AppearanceFragment;
-import com.nugget.hios.ui.preferences.PrivacypolicyFragment;
 
-public class HiClubSettingsActivity extends AppCompatActivity {
+public class HelpcenterActivity extends AppCompatActivity {
 
     private CollapsingToolbarLayout collapsingToolbar;
     private AppBarLayout appBarLayout;
 
-    private static final String TITLE_HOME = "Settings";
+    private static final String TITLE_HOME = "Help";
 
-    // Helper to load sub-pages
+    //Helper to load subpages
     private void loadFragment(Fragment fragment, String title) {
         getSupportFragmentManager().beginTransaction()
                 .setCustomAnimations(
                         R.anim.slide_in_right, R.anim.slide_out_left, R.anim.slide_in_left, R.anim.slide_out_right
                 )
-                .replace(R.id.settings_container, fragment)
-                .addToBackStack(title)   // store title for back navigation
+                .replace(R.id.helpcenter_container, fragment)
+                .addToBackStack(title)
                 .commit();
 
         collapsingToolbar.setTitle(title);
@@ -38,9 +35,9 @@ public class HiClubSettingsActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_hiclub_settings);
+        setContentView(R.layout.activity_helpcenter);
 
-        // Toolbar setup
+        //toolbar setup
         MaterialToolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         if (getSupportActionBar() != null) {
@@ -51,20 +48,20 @@ public class HiClubSettingsActivity extends AppCompatActivity {
         collapsingToolbar = findViewById(R.id.collapsing_toolbar);
         collapsingToolbar.setTitle(TITLE_HOME);
 
-        // Load the home fragment once
+        //load home fragment once.
         if (savedInstanceState == null) {
             getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.settings_container,
+                    .replace(R.id.helpcenter_container,
                             GenericLayoutFragment.newInstance(
-                                    R.layout.fragment_home_settings,
-                                    "Settings",
-                                    "settings_home"
+                                    R.layout.fragment_home_helpcenter,
+                                    "Help",
+                                    "helpcenter_home"
                             )
                     )
                     .commit();
         }
 
-        // Keep title in sync with back stack
+        //keep title in sync with back stack.
         getSupportFragmentManager().addOnBackStackChangedListener(() -> {
             int count = getSupportFragmentManager().getBackStackEntryCount();
 
@@ -81,13 +78,10 @@ public class HiClubSettingsActivity extends AppCompatActivity {
         });
     }
 
-    // --- Called from SettingsHomeFragment ---
+    //called from HelpcenterHomeFragment
 
-    public void openAppearance() {
-        loadFragment(new AppearanceFragment(), "Customise HiOSCore");
-    }
-
-    public void openUpdates() {
+    /*e.g...
+        public void openUpdates() {
         loadFragment(GenericLayoutFragment.newInstance(
                 R.layout.fragment_updates_settings,
                 "Updates",
@@ -105,15 +99,8 @@ public class HiClubSettingsActivity extends AppCompatActivity {
             ),
                 "Apps and Services"
         );
-    }
-
-    public void openAbout() {
-        loadFragment(new AboutFragment(), "About HiOSMobile");
-    }
-
-    public void openPrivacyPolicy() {
-        loadFragment(new PrivacypolicyFragment(), "Privacy Policy");
-    }
+    } etc etc etc
+     */
 
     @Override
     public boolean onSupportNavigateUp() {

--- a/app/src/main/java/com/nugget/hios/MainActivity.java
+++ b/app/src/main/java/com/nugget/hios/MainActivity.java
@@ -214,6 +214,11 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
         View sheetView = getLayoutInflater().inflate(R.layout.layout_menu_bottom_sheet, null);
         bottomSheetDialog.setContentView(sheetView);
 
+        sheetView.findViewById(R.id.topmenuDownloadmenus).setOnClickListener(view -> {
+            downloadmenus(null);
+            bottomSheetDialog.dismiss();
+        });
+
         sheetView.findViewById(R.id.topmenuSettings).setOnClickListener(view -> {
             settings(null);
             bottomSheetDialog.dismiss();
@@ -244,7 +249,12 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     }
 
     //ONCLICK LISTENERS GOING TO PAGES ON TOOLBAR/POPUP
-
+    public boolean downloadmenus(MenuItem item) {
+        Uri uri = Uri.parse("https://www.dropbox.com/scl/fo/7gmlnnjcau1np91ee83ht/h?rlkey=ifj506k3aal7ko7tfecy8oqyq&dl=0");
+        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        startActivity(intent);
+        return true;
+    }
 
     public boolean settings(MenuItem item) {
         startActivity(new Intent(MainActivity.this, HiClubSettingsActivity.class));

--- a/app/src/main/java/com/nugget/hios/MainActivity.java
+++ b/app/src/main/java/com/nugget/hios/MainActivity.java
@@ -252,9 +252,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     }
 
     public boolean help(MenuItem item) {
-        Uri uri = Uri.parse("https://thehighlandcafe.github.io/hiosmobileweb/activities/activity_help.html");
-        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-        startActivity(intent);
+        startActivity(new Intent(MainActivity.this, HelpcenterActivity.class));
         return true;
     }
 

--- a/app/src/main/java/com/nugget/hios/ui/common/ScreenBinder.java
+++ b/app/src/main/java/com/nugget/hios/ui/common/ScreenBinder.java
@@ -22,6 +22,7 @@ import androidx.webkit.internal.ApiFeature;
 
 import com.google.android.material.textfield.MaterialAutoCompleteTextView;
 import com.nugget.hios.HiClubSettingsActivity;
+import com.nugget.hios.HelpcenterActivity;
 import com.nugget.hios.R;
 import com.nugget.hios.ui.preferences.AboutFragment;
 import com.nugget.hios.updates.GithubUpdater;
@@ -51,6 +52,10 @@ public final class ScreenBinder {
                 //TODO: was needing to add websites and socials settings...
             case "socials_settings":
                 bindSocialsSettings(root, activity);*/
+
+            case "helpcenter_home":
+                bindHelpcenterHome(root, activity);
+                break;
 
             default:
                 break;
@@ -245,6 +250,101 @@ public final class ScreenBinder {
         if (nuggetdevButton != null) {
             nuggetdevButton.setOnClickListener(view -> {
                 openWebsite(activity, "https://hienterprises.github.io/nuggetdev/home");
+            });
+        }
+    }
+
+    /*
+    This is the ScreenBinder for the help center -- it just needs the helpcenterhome screen binder, since it's all fragments.
+     */
+    private static void bindHelpcenterHome(View root, Activity activity) {
+        View tutorial = root.findViewById(R.id.btn_tutorial);
+        if (tutorial != null) {
+            tutorial.setOnClickListener(view -> {
+                if (activity instanceof HelpcenterActivity) {
+                    ((HelpcenterActivity) activity).openTutorial();
+                }
+            });
+        }
+
+        View food = root.findViewById(R.id.btn_foodhelp);
+        if (food != null) {
+            food.setOnClickListener(view -> {
+                if (activity instanceof HelpcenterActivity) {
+                    ((HelpcenterActivity) activity).openFood();
+                }
+            });
+        }
+
+        View hotel = root.findViewById(R.id.btn_hotelhelp);
+        if (hotel != null) {
+            hotel.setOnClickListener(view -> {
+                if (activity instanceof HelpcenterActivity) {
+                    ((HelpcenterActivity) activity).openHotel();
+                }
+            });
+        }
+
+        View roomkey = root.findViewById(R.id.btn_roomkeyhelp);
+        if (roomkey != null) {
+            roomkey.setOnClickListener(view -> {
+                if (activity instanceof HelpcenterActivity) {
+                    ((HelpcenterActivity) activity).openRoomkey();
+                }
+            });
+        }
+
+        View support = root.findViewById(R.id.btn_supporthelp);
+        if (support != null) {
+            support.setOnClickListener(view -> {
+                if (activity instanceof HelpcenterActivity) {
+                    ((HelpcenterActivity) activity).openSupport();
+                }
+            });
+        }
+
+        View internet = root.findViewById(R.id.btn_internethelp);
+        if (internet != null) {
+            internet.setOnClickListener(view -> {
+                if (activity instanceof HelpcenterActivity) {
+                    ((HelpcenterActivity) activity).openInternet();
+                }
+            });
+        }
+
+        View updates = root.findViewById(R.id.btn_updateshelp);
+        if (updates != null) {
+            updates.setOnClickListener(view -> {
+                if (activity instanceof HelpcenterActivity) {
+                    ((HelpcenterActivity) activity).openUpdates();
+                }
+            });
+        }
+
+        View comingSoon = root.findViewById(R.id.btn_comingsoon);
+        if (comingSoon != null) {
+            comingSoon.setOnClickListener(view -> {
+                if (activity instanceof HelpcenterActivity) {
+                    ((HelpcenterActivity) activity).comingSoon();
+                }
+            });
+        }
+
+        View termsConditions = root.findViewById(R.id.btn_termsconditions);
+        if (termsConditions != null) {
+            termsConditions.setOnClickListener(view -> {
+                if (activity instanceof HelpcenterActivity) {
+                    ((HelpcenterActivity) activity).termsConditions();
+                }
+            });
+        }
+
+        View feedback = root.findViewById(R.id.btn_feedback);
+        if (feedback != null) {
+            feedback.setOnClickListener(view -> {
+                if (activity instanceof HelpcenterActivity) {
+                    ((HelpcenterActivity) activity).sendFeedback();
+                }
             });
         }
     }

--- a/app/src/main/java/com/nugget/hios/updates/GithubUpdater.java
+++ b/app/src/main/java/com/nugget/hios/updates/GithubUpdater.java
@@ -1,5 +1,6 @@
 package com.nugget.hios.updates;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.DownloadManager;
 import android.content.BroadcastReceiver;
@@ -45,7 +46,7 @@ public class GithubUpdater {
                     if (!updateAvailable) {
                         new AlertDialog.Builder(activity)
                                 .setTitle("Up to date")
-                                .setMessage("You already have the latest version of HiClub installed.")
+                                .setMessage("You already have the latest version of HiOSMobile installed.")
                                 .setPositiveButton("Ok cool", null)
                                 .show();
                         return;
@@ -69,6 +70,7 @@ public class GithubUpdater {
         });
     }
 
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
     private static void downloadAndInstall(Activity activity, String apkUrl) {
         //Android 8+ needs per-app permission to install apks, so a check is necessary.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/app/src/main/res/anim/slide_in_left.xml
+++ b/app/src/main/res/anim/slide_in_left.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="250"
+    android:fromXDelta="-100%"
+    android:toXDelta="0%"
+    android:interpolator="@android:interpolator/fast_out_slow_in" />

--- a/app/src/main/res/anim/slide_in_right.xml
+++ b/app/src/main/res/anim/slide_in_right.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="250"
+    android:fromXDelta="100%"
+    android:toXDelta="0%"
+    android:interpolator="@android:interpolator/fast_out_slow_in" />

--- a/app/src/main/res/anim/slide_out_left.xml
+++ b/app/src/main/res/anim/slide_out_left.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="250"
+    android:fromXDelta="0%"
+    android:toXDelta="-100%"
+    android:interpolator="@android:interpolator/fast_out_slow_in" />

--- a/app/src/main/res/anim/slide_out_right.xml
+++ b/app/src/main/res/anim/slide_out_right.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="250"
+    android:fromXDelta="0%"
+    android:toXDelta="100%"
+    android:interpolator="@android:interpolator/fast_out_slow_in" />

--- a/app/src/main/res/drawable/back.xml
+++ b/app/src/main/res/drawable/back.xml
@@ -5,6 +5,6 @@
     android:viewportHeight="960"
     android:tint="?colorControlNormal">
   <path
-      android:pathData="m142,480 l294,294q15,15 14.5,35T435,844q-15,15 -35,15t-35,-15L57,537q-12,-12 -18,-27t-6,-30q0,-15 6,-30t18,-27l308,-308q15,-15 35.5,-14.5T436,116q15,15 15,35t-15,35L142,480Z"
-      android:fillColor="@android:color/white"/>
+      android:pathData="m313,520 l196,196q12,12 11.5,28T508,772q-12,11 -28,11.5T452,772L188,508q-6,-6 -8.5,-13t-2.5,-15q0,-8 2.5,-15t8.5,-13l264,-264q11,-11 27.5,-11t28.5,11q12,12 12,28.5T508,245L313,440h447q17,0 28.5,11.5T800,480q0,17 -11.5,28.5T760,520L313,520Z"
+      android:fillColor="@color/white"/>
 </vector>

--- a/app/src/main/res/layout/activity_helpcenter.xml
+++ b/app/src/main/res/layout/activity_helpcenter.xml
@@ -34,12 +34,11 @@
         </com.google.android.material.appbar.CollapsingToolbarLayout>
     </com.google.android.material.appbar.AppBarLayout>
 
-    <!-- IMPORTANT: empty container; your "Preferences" UI lives in fragment_preferences_home.xml now -->
+    <!--Empty container for fragments-->
     <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/settings_container"
+        android:id="@+id/helpcenter_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:name="com.nugget.hios.ui.common.GenericLayoutFragment" />
-
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_apps_settings.xml
+++ b/app/src/main/res/layout/fragment_apps_settings.xml
@@ -27,7 +27,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="3dp"
             app:shapeAppearanceOverlay="@style/Shape.Card.TopRoundedOnly"
-            app:cardBackgroundColor="?attr/colorPrimaryContainer"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
             app:cardElevation="0dp">
 
             <LinearLayout
@@ -86,7 +86,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
         app:shapeAppearanceOverlay="@style/Shape.Card.BottomRoundedOnly"
-        app:cardBackgroundColor="?attr/colorPrimaryContainer"
+        app:cardBackgroundColor="?attr/colorSurfaceContainer"
         app:cardElevation="0dp">
 
         <LinearLayout
@@ -145,7 +145,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="3dp"
         app:cardCornerRadius="20dp"
-        app:cardBackgroundColor="?attr/colorPrimaryContainer"
+        app:cardBackgroundColor="?attr/colorSurfaceContainer"
         app:cardElevation="0dp">
 
         <LinearLayout

--- a/app/src/main/res/layout/fragment_home_helpcenter.xml
+++ b/app/src/main/res/layout/fragment_home_helpcenter.xml
@@ -111,7 +111,7 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-                <!-- Updates -->
+                <!-- Food Help -->
                 <LinearLayout
                     android:id="@+id/btn_foodhelp"
                     android:layout_width="match_parent"
@@ -141,6 +141,386 @@
                         android:layout_height="24dp"
                         android:src="@drawable/ic_chevron" />
                 </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Widget.Material3.CardView.Filled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="3dp"
+            app:shapeAppearanceOverlay="@style/Shape.Card.SquaredOff"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/btn_hotelhelp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/card_inner_middle_padding">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_worsteasternicon" />
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="16dp"
+                        android:text="@string/title_notifications"
+                        style="@style/TextAppearance.Material3.BodyLarge" />
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_chevron" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Widget.Material3.CardView.Filled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="3dp"
+            app:shapeAppearanceOverlay="@style/Shape.Card.SquaredOff"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/btn_roomkeyhelp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/card_inner_middle_padding">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_keyicon" />
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="16dp"
+                        android:text="@string/title_roomkey"
+                        style="@style/TextAppearance.Material3.BodyLarge" />
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_chevron" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Widget.Material3.CardView.Filled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="3dp"
+            app:shapeAppearanceOverlay="@style/Shape.Card.SquaredOff"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/btn_supporthelp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/card_inner_middle_padding">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_support" />
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="16dp"
+                        android:text="@string/title_activity_support"
+                        style="@style/TextAppearance.Material3.BodyLarge" />
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_chevron" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Widget.Material3.CardView.Filled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="3dp"
+            app:shapeAppearanceOverlay="@style/Shape.Card.SquaredOff"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/btn_internethelp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/card_inner_middle_padding">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_interneticon" />
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="16dp"
+                        android:text="@string/internet_header"
+                        style="@style/TextAppearance.Material3.BodyLarge" />
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_chevron" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Widget.Material3.CardView.Filled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:shapeAppearanceOverlay="@style/Shape.Card.BottomRoundedOnly"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/btn_updateshelp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/card_inner_padding">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_update" />
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="16dp"
+                        android:text="@string/updates_header"
+                        style="@style/TextAppearance.Material3.BodyLarge" />
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_chevron" />
+                </LinearLayout>
+
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <!-- SECTION 3: MORE-->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/title_more"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="8dp"
+            android:layout_marginStart="12dp"
+            style="@style/TextAppearance.Material3.LabelLarge"
+            android:textColor="?android:attr/textColorSecondary"/>
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Widget.Material3.CardView.Filled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="3dp"
+            app:shapeAppearanceOverlay="@style/Shape.Card.TopRoundedOnly"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <!-- Updates -->
+                <LinearLayout
+                    android:id="@+id/btn_comingsoon"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/card_inner_padding">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_moreicon" />
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="16dp"
+                        android:text="@string/title_comingsoon"
+                        style="@style/TextAppearance.Material3.BodyLarge" />
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_chevron" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Widget.Material3.CardView.Filled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="3dp"
+            app:shapeAppearanceOverlay="@style/Shape.Card.SquaredOff"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/btn_termsconditions"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/card_inner_middle_padding">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_aboutapp" />
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="16dp"
+                        android:text="@string/title_activity_tc"
+                        style="@style/TextAppearance.Material3.BodyLarge" />
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_chevron" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Widget.Material3.CardView.Filled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:shapeAppearanceOverlay="@style/Shape.Card.BottomRoundedOnly"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/btn_feedback"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/card_inner_padding">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_feedback" />
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="16dp"
+                        android:text="@string/title_activity_feedback"
+                        style="@style/TextAppearance.Material3.BodyLarge" />
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_chevron" />
+                </LinearLayout>
+
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_home_helpcenter.xml
+++ b/app/src/main/res/layout/fragment_home_helpcenter.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/helpcenter_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    android:clipToPadding="false">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="@dimen/adaptive_horizontal_margin"
+        android:paddingBottom="24dp"
+        android:clipToPadding="false">
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_home_helpcenter.xml
+++ b/app/src/main/res/layout/fragment_home_helpcenter.xml
@@ -15,5 +15,133 @@
         android:paddingHorizontal="@dimen/adaptive_horizontal_margin"
         android:paddingBottom="24dp"
         android:clipToPadding="false">
+
+        <!-- SECTION 1: TUTORIAL-->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/tutorial_title"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="8dp"
+            android:layout_marginStart="12dp"
+            style="@style/TextAppearance.Material3.LabelLarge"
+            android:textColor="?android:attr/textColorSecondary"/>
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Widget.Material3.CardView.Filled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:cardCornerRadius="20dp"
+            android:layout_marginBottom="8dp"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/btn_tutorial"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_horizontal"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/card_inner_padding">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_tutorial"/>
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="16dp"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/tutorial_header"
+                            style="@style/TextAppearance.Material3.BodyLarge"/>
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/tutorial_summary"
+                            style="@style/TextAppearance.Material3.BodySmall"
+                            android:textColor="?colorOnSurface"/>
+                    </LinearLayout>
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_chevron"/>
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <!-- SECTION 2: GENERAL HELP-->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/general_title"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="8dp"
+            android:layout_marginStart="12dp"
+            style="@style/TextAppearance.Material3.LabelLarge"
+            android:textColor="?android:attr/textColorSecondary"/>
+
+        <com.google.android.material.card.MaterialCardView
+            style="@style/Widget.Material3.CardView.Filled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="3dp"
+            app:shapeAppearanceOverlay="@style/Shape.Card.TopRoundedOnly"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <!-- Updates -->
+                <LinearLayout
+                    android:id="@+id/btn_foodhelp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/card_inner_padding">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_restauranticon" />
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="16dp"
+                        android:text="@string/title_dashboard"
+                        style="@style/TextAppearance.Material3.BodyLarge" />
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_chevron" />
+                </LinearLayout>
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_home_settings.xml
+++ b/app/src/main/res/layout/fragment_home_settings.xml
@@ -33,7 +33,7 @@
             android:layout_height="wrap_content"
             app:cardCornerRadius="20dp"
             android:layout_marginBottom="8dp"
-            app:cardBackgroundColor="?attr/colorPrimaryContainer"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
             app:cardElevation="0dp">
 
             <LinearLayout
@@ -93,7 +93,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:shapeAppearanceOverlay="@style/Shape.Card.TopRoundedOnly"
-            app:cardBackgroundColor="?attr/colorPrimaryContainer"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
             android:layout_marginBottom="3dp"
             app:cardElevation="0dp">
 
@@ -157,7 +157,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:shapeAppearanceOverlay="@style/Shape.Card.BottomRoundedOnly"
-            app:cardBackgroundColor="?attr/colorPrimaryContainer"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
             app:cardElevation="0dp">
 
             <LinearLayout
@@ -222,7 +222,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="3dp"
             app:shapeAppearanceOverlay="@style/Shape.Card.TopRoundedOnly"
-            app:cardBackgroundColor="?attr/colorPrimaryContainer"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
             app:cardElevation="0dp">
 
             <LinearLayout
@@ -268,7 +268,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:shapeAppearanceOverlay="@style/Shape.Card.BottomRoundedOnly"
-            app:cardBackgroundColor="?attr/colorPrimaryContainer"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
             app:cardElevation="0dp">
 
             <LinearLayout
@@ -315,7 +315,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="3dp"
             app:shapeAppearanceOverlay="@style/Shape.Card.SquaredOff"
-            app:cardBackgroundColor="?attr/colorPrimaryContainer"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
             app:cardElevation="0dp">
 
             <LinearLayout
@@ -360,7 +360,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:shapeAppearanceOverlay="@style/Shape.Card.BottomRoundedOnly"
-            app:cardBackgroundColor="?attr/colorPrimaryContainer"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
             app:cardElevation="0dp">
 
             <LinearLayout
@@ -417,7 +417,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:cardCornerRadius="20dp"
-            app:cardBackgroundColor="?attr/colorPrimaryContainer"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
             app:cardElevation="0dp">
 
             <LinearLayout
@@ -474,7 +474,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:cardCornerRadius="20dp"
-            app:cardBackgroundColor="?attr/colorPrimaryContainer"
+            app:cardBackgroundColor="?attr/colorSurfaceContainer"
             app:cardElevation="0dp">
 
             <LinearLayout

--- a/app/src/main/res/layout/fragment_updates_settings.xml
+++ b/app/src/main/res/layout/fragment_updates_settings.xml
@@ -27,7 +27,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="3dp"
         app:shapeAppearanceOverlay="@style/Shape.Card.TopRoundedOnly"
-        app:cardBackgroundColor="?attr/colorPrimaryContainer"
+        app:cardBackgroundColor="?attr/colorSurfaceContainer"
         app:cardElevation="0dp">
 
         <LinearLayout
@@ -86,7 +86,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:shapeAppearanceOverlay="@style/Shape.Card.BottomRoundedOnly"
-        app:cardBackgroundColor="?attr/colorPrimaryContainer"
+        app:cardBackgroundColor="?attr/colorSurfaceContainer"
         app:cardElevation="0dp">
 
         <LinearLayout
@@ -156,7 +156,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:cardCornerRadius="20dp"
-        app:cardBackgroundColor="?attr/colorPrimaryContainer"
+        app:cardBackgroundColor="?attr/colorSurfaceContainer"
         app:cardElevation="0dp">
 
         <LinearLayout
@@ -227,7 +227,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="3dp"
         app:shapeAppearanceOverlay="@style/Shape.Card.TopRoundedOnly"
-        app:cardBackgroundColor="?attr/colorPrimaryContainer"
+        app:cardBackgroundColor="?attr/colorSurfaceContainer"
         app:cardElevation="0dp">
 
         <LinearLayout
@@ -286,7 +286,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:shapeAppearanceOverlay="@style/Shape.Card.BottomRoundedOnly"
-        app:cardBackgroundColor="?attr/colorPrimaryContainer"
+        app:cardBackgroundColor="?attr/colorSurfaceContainer"
         app:cardElevation="0dp">
 
         <LinearLayout

--- a/app/src/main/res/layout/layout_menu_bottom_sheet.xml
+++ b/app/src/main/res/layout/layout_menu_bottom_sheet.xml
@@ -27,6 +27,55 @@
         style="@style/Widget.Material3.CardView.Filled"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        app:cardCornerRadius="20dp"
+        app:cardBackgroundColor="?attr/colorSurfaceContainer"
+        app:cardElevation="0dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+            <LinearLayout
+                android:id="@+id/topmenuDownloadmenus"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:padding="@dimen/card_inner_padding">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_menu"
+                    android:contentDescription="@null" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="16dp"
+                    android:text="@string/download_menus"
+                    style="@style/TextAppearance.Material3.BodyLarge"/>
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_chevron"
+                    android:contentDescription="@null"
+                    app:tint="?android:attr/textColorSecondary"/>
+            </LinearLayout>
+
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        style="@style/Widget.Material3.CardView.Filled"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginBottom="3dp"
         app:shapeAppearanceOverlay="@style/Shape.Card.TopRoundedOnly"
         app:cardBackgroundColor="?attr/colorSurfaceContainer"
@@ -77,7 +126,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp"
         app:shapeAppearanceOverlay="@style/Shape.Card.BottomRoundedOnly"
-        app:cardBackgroundColor="?attr/colorPrimaryContainer"
+        app:cardBackgroundColor="?attr/colorSurfaceContainer"
         app:cardElevation="0dp">
 
         <LinearLayout
@@ -127,7 +176,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp"
         app:cardCornerRadius="20dp"
-        app:cardBackgroundColor="?attr/colorPrimaryContainer"
+        app:cardBackgroundColor="?attr/colorSurfaceContainer"
         app:cardElevation="0dp">
 
         <LinearLayout

--- a/app/src/main/res/layout/layout_menu_bottom_sheet.xml
+++ b/app/src/main/res/layout/layout_menu_bottom_sheet.xml
@@ -29,7 +29,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="3dp"
         app:shapeAppearanceOverlay="@style/Shape.Card.TopRoundedOnly"
-        app:cardBackgroundColor="?attr/colorPrimaryContainer"
+        app:cardBackgroundColor="?attr/colorSurfaceContainer"
         app:cardElevation="0dp">
 
         <LinearLayout

--- a/app/src/main/res/menu/toolbaricon.xml
+++ b/app/src/main/res/menu/toolbaricon.xml
@@ -7,6 +7,16 @@
         android:title="@string/title_more"
         app:showAsAction="always">
         <menu>
+            <group
+                android:id="@+id/toolbaricon_2">
+
+                <item
+                    android:id="@+id/topmenuDownloadmenus"
+                    android:title="@string/download_menus"
+                    android:icon="@drawable/ic_menu"
+                    android:onClick="downloadmenus" />
+
+            </group>
 
             <group
                 android:id="@+id/toolbaricon_3">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,8 +42,8 @@
     <string name="title_activity_tc">Terms and Conditions</string>
     <string name="title_activity_support">Customer Support</string>
 
-    <string name="download_menus">Download Menus</string>
-    <string name="visit_blog">Visit HiEnterprises™ Blog</string>
+    <string name="download_menus">Download menus</string>
+    <string name="visit_blog">Visit our blog</string>
 
     <!-- Settings Titles -->
     <string name="section_customisation">Customisation</string>


### PR DESCRIPTION
## 🚀 Summary

This pull request introduces version 3.1 of HiOSMobile. The headline feature is the implementation of a fully Native Help Center, replacing the previous external web redirects. This update also brings significant UI polish, specifically transitioning card backgrounds to standard Material 3 surface containers and adding fluid slide animations.

## 📝 Key Changes

### 🆘 Native Help Center

- New Activity: Implemented HelpcenterActivity to host the help interface natively within the app.

- Expanded Content: Added dedicated sections for:

> Tutorial & General Help
> 
> Hotel Services
> 
> Room Key Support
> 
> Internet & Updates support

- Navigation: Integrated ScreenBinder logic to handle click events for all new help categories and added fragment navigation methods.

## 🎨 UI/UX Polish

- Animations: Added custom slide_in_right and slide_out_left animations for smoother fragment transitions in both Settings and Help Center.

- Material 3 Updates:

> Updated MaterialCardView backgrounds in Home, Apps, and Updates settings from colorPrimaryContainer to colorSurfaceContainer for better visual hierarchy.
> 
> Updated the Menu Bottom Sheet background to colorSurfaceContainer.

- Assets: Refined the back.xml vector drawable with updated paths.

- Download Menus: Integrated a "Download menus" feature accessible via the Toolbar and Bottom Sheet dialog.

## ⚙️ Technical & Maintenance

- Branding Cleanup: Fixed residual "HiClub" references in the update check completion message; updated to "HiOSMobile".

- Linting: Added @SuppressLint("UnspecifiedRegisterReceiverFlag") to downloadAndInstall to support newer Android API requirements.

- Configuration: Added IDE configuration files for Markdown preview and Studio Bot settings.

- Versioning: Bumped versionName to 3.1 in build.gradle.